### PR TITLE
make possibly undefined arguments optional

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import { Noop, Request, Requests, Response, Responses } from "./types";
+import { IfMaybeUndefined, Noop, Request, Requests, Response, Responses } from "./types";
 
 /**
  * The callback function that will be called to send the request to the server.
@@ -44,7 +44,11 @@ export class JsonRpcClient<T extends { [k: string]: any }> {
    */
   call<Method extends keyof T>(
     method: Method,
-    params: Requests<T>[Method][0]
+    ...[params]: IfMaybeUndefined<
+      Requests<T>[Method][0],
+      [params?: Requests<T>[Method][0]],
+      [params: Requests<T>[Method][0]]
+    >
   ): Promise<NonNullable<Responses<T>[Method]["result"]>> {
     const requestData = { jsonrpc: "2.0", id: this.id++, method: method.toString(), params } as const;
     return new Promise<NonNullable<Responses<T>[Method]["result"]>>((resolve, reject) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,4 +89,4 @@ export type Requests<Methods extends Record<string, Noop>> = {
   [Method in keyof Methods]: Parameters<Methods[Method]>;
 };
 
-export type IfMaybeUndefined<T, True, False> = [T] extends [undefined] ? True : False;
+export type IfMaybeUndefined<T, True, False> = [undefined] extends [T] ? True : False;

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,3 +88,5 @@ export type Responses<Methods extends Record<string, Noop>> = {
 export type Requests<Methods extends Record<string, Noop>> = {
   [Method in keyof Methods]: Parameters<Methods[Method]>;
 };
+
+export type IfMaybeUndefined<T, True, False> = [T] extends [undefined] ? True : False;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -17,7 +17,7 @@ client.sender = async (request) => {
 };
 
 it("will send and receive messages", async () => {
-  const { text } = await client.call("ping", undefined);
+  const { text } = await client.call("ping");
   expect(text).toBe("pong");
 });
 


### PR DESCRIPTION
## Summary

Adjusts types so that parameters that are potentially undefined (or functions with no parameters, which end up being undefined) are optional

Ref #(issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Checking TSC is happy with the tests

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] I have requested review from the maintainers
- [x] My code follows the [style guidelines](https://github.com/AdeAttwood/JsJsonRpc/blob/0.x/CONTRIBUTING.md#coding-style) of this project
- [ ] My commits are [formatted correctly](https://github.com/AdeAttwood/JsJsonRpc/blob/0.x/CONTRIBUTING.md#committing-convention)
